### PR TITLE
Rewrite fetch_and_pickle_schedule.py to only use Debian packages.

### DIFF
--- a/bin/fetch_and_pickle_schedule.py
+++ b/bin/fetch_and_pickle_schedule.py
@@ -8,9 +8,9 @@ import os
 import pickle
 import sys
 from datetime import date, timedelta
+
 import dateutil.parser
 import pytz
-
 import requests
 
 

--- a/bin/fetch_and_pickle_schedule.py
+++ b/bin/fetch_and_pickle_schedule.py
@@ -16,7 +16,8 @@ import requests
 
 def from_scheduleitem_to_playout(si):
     starttime = (dateutil.parser.parse(si['starttime'])
-                 .astimezone(pytz.timezone("Europe/Oslo")))
+                 .astimezone(pytz.timezone("Europe/Oslo"))
+                 .replace(tzinfo=None))
     # custom duration parser (to ms)
     duration = 1000 * sum(
         (60**n) * float(e)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,3 @@ git+git://github.com/Frikanalen/python-vlc.git@fixed_setup_py#egg=python-vlc
 # OS package manager.
 
 requests==2.20.0
-# The newer pendulum version don't work on Wheezy
-pendulum==1.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,6 @@ git+git://github.com/Frikanalen/python-vlc.git@fixed_setup_py#egg=python-vlc
 # You also need VLC, MLT and mlt-python, but those are better done through your
 # OS package manager.
 
+python-dateutil
+pytz
 requests==2.20.0


### PR DESCRIPTION
Drop the dependency on pendulum to make it easier to test the script
on Debian without providing a special python environment.